### PR TITLE
Display form input on hello.html

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,7 @@ azure_deployment = os.getenv('AZURE_OPENAI_DEPLOYMENT')
 @app.route('/hello', methods=['POST'])
 def hello():
     req = request.form.get('req')
+    original_req = req  # Pc639
 
     token = auth.get_token_for_client(app_config.SCOPE)
     if "error" in token:
@@ -62,7 +63,7 @@ def hello():
 
     if req:
         print('Request for hello page received with req=%s' % req)
-        return render_template('hello.html', req = text)
+        return render_template('hello.html', req=text, original_req=original_req)  # P2b66
     else:
         print('Request for hello page received with no name or blank name -- redirecting')
         return redirect(url_for('index'))

--- a/templates/hello.html
+++ b/templates/hello.html
@@ -10,6 +10,9 @@
         <div class="px-4 py-3 my-2 text-center">
             <img class="d-block mx-auto mb-4" src="{{ url_for('static', filename='images/azure-icon.svg') }}" alt="Azure Logo" width="192" height="192"/>
             <!-- <img  src="/docs/5.1/assets/brand/bootstrap-logo.svg" alt="" width="72" height="57"> -->
+            <p class="fs-5">
+                Original input: {{original_req}}
+            </p>
             <h1 class="display-6 fw-bold">OpenAI response:</h1>
             <p class="fs-5">
                 {{req}}


### PR DESCRIPTION
Fixes #6

Display the original form input on `hello.html`.

* **templates/hello.html**
  - Add a new paragraph to display the original form input above the OpenAI response.
  - Use the `original_req` variable to display the original form input.

* **app.py**
  - Modify the `/hello` route to pass the original form input to `hello.html`.
  - Add a new variable `original_req` to store the original form input.
  - Pass the original form input to the `render_template` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/a09-capf/msdocs-python-flask-webapp-quickstart/pull/7?shareId=345274f7-47c7-4914-b08e-511b9d900436).